### PR TITLE
Update cloudpassage lib

### DIFF
--- a/cloudpassage/cloudpassage.py
+++ b/cloudpassage/cloudpassage.py
@@ -23,7 +23,7 @@ class Token(str):
         if headers is None:
             headers = {}
         headers['Content-Type'] = 'application/json'
-        req = requests.post(url, data=data, headers=headers, verify=False)
+        req = requests.post(url, data=data, headers=headers)
         req.raise_for_status()
         json = req.json()
         if u'error' in json:
@@ -88,7 +88,7 @@ class CloudPassage:
     def __get(self, endpoint):
         headers = {'Authorization': 'Bearer %s' % self.token}
         url = self.baseurl + endpoint
-        req = requests.get(url, headers=headers, verify=False)
+        req = requests.get(url, headers=headers)
         return self.__parserequest(req)
 
     def __post(self, endpoint, data=None):
@@ -98,7 +98,7 @@ class CloudPassage:
         headers = {'Authorization': 'Bearer %s' % self.token,
                    'Content-Type': 'application/json'}
         url = self.baseurl + endpoint
-        req = requests.post(url, data=data, headers=headers, verify=False)
+        req = requests.post(url, data=data, headers=headers)
         return self.__parserequest(req)
 
     def __put(self, endpoint, data=None):
@@ -108,7 +108,7 @@ class CloudPassage:
         headers = {'Authorization': 'Bearer %s' % self.token,
                    'Content-Type': 'application/json'}
         url = self.baseurl + endpoint
-        req = requests.put(url, data=data, headers=headers, verify=False)
+        req = requests.put(url, data=data, headers=headers)
         return self.__parserequest(req)
 
     def __parserequest(self, req):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os
+import sys
 try:
     from setuptools import setup
 except ImportError:
@@ -9,6 +10,15 @@ def read(*paths):
     """Build a file path from *paths* and return the contents."""
     with open(os.path.join(*paths), 'r') as f:
         return f.read()
+
+install_requires = ['requests >= 2.1.0']
+
+# For SNI support (required by CloudPassage) in Python 2, must install the
+# following packages
+if sys.version_info[0] == 2:
+    install_requires.append('pyOpenSSL >= 0.14')
+    install_requires.append('ndg-httpsclient >= 0.3.3')
+    install_requires.append('pyasn1 >= 0.1.7')
 
 setup(
     name='cloudpassage',
@@ -23,7 +33,7 @@ setup(
     author='Ryan Gooler',
     author_email='ryan.gooler@gmail.com',
     py_modules=['cloudpassage'],
-    install_requires=['requests >= 2.1.0'],
+    install_requires=install_requires,
     include_package_data=True,
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
- Disable SSL certificate checks
  - Failing with: `*** SSLError: hostname 'api.cloudpassage.com' doesn't match 'grid.cloudpassage.com'`
- Add `__put` utility method
- Add some other API wrappers:
  - list_server_group_servers
  - list_servers
  - get_server
  - retire_server
- Fix `search_server_groups` call to `__get`
